### PR TITLE
Fix task add button handler

### DIFF
--- a/components/views/Task.js
+++ b/components/views/Task.js
@@ -1,8 +1,10 @@
 import html from "html-literal";
 
+const API_BASE = process.env.CAPSTONE_API || "http://localhost:4040";
+
 export const fetchTasks = async () => {
   try {
-    const response = await fetch(`${process.env.CAPSTONE_API}/tasks`);
+    const response = await fetch(`${API_BASE}/tasks`);
     const tasks = await response.json();
     const ulElement = document.querySelector(".task-app ul");
     ulElement.innerHTML = ""; // Clear existing task list
@@ -24,7 +26,7 @@ export const fetchTasks = async () => {
 
 export const deleteTask = async taskId => {
   try {
-    await fetch(`${process.env.CAPSTONE_API}/tasks/delete/task/${taskId}`, {
+    await fetch(`${API_BASE}/tasks/delete/task/${taskId}`, {
       method: "DELETE"
     });
     fetchTasks();

--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ import Navigo from "navigo";
 import { capitalize } from "lodash";
 import { fetchTasks } from "./components/views/Task";
 
+const API_BASE = process.env.CAPSTONE_API || "http://localhost:4040";
+
 const router = new Navigo("/");
 
 function render(state = store.Home) {
@@ -26,47 +28,35 @@ function afterRender(state) {
 
   const form = document.querySelector("#task-form");
   const taskInput = document.querySelector("#task-input");
-  const taskSubmitButton = document
-    .querySelector("#task-submit")
-    .addEventListener("click", async () => {
-      const taskInputElement = document.querySelector("#task-input");
-      if (taskInputElement.value.trim() === "") {
-        alert("Please enter a task!");
-      } else {
-        const task = taskInputElement.value;
-        await fetch(`${process.env.CAPSTONE_API}/tasks/add/task`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ task: task })
-        });
-        taskInputElement.value = "";
-        fetchTasks();
-      }
-    });
+  const taskSubmitButton = document.querySelector("#task-submit");
 
   if (form && taskInput && taskSubmitButton) {
-    taskSubmitButton.addEventListener("click", async () => {
+    taskSubmitButton.addEventListener("click", async event => {
+      event.preventDefault();
       const taskValue = taskInput.value.trim();
 
-      if (taskValue) {
-        const response = await fetch(
-          `${process.env.CAPSTONE_API}/tasks/add/task`,
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json"
-            },
-            body: JSON.stringify({ task: taskValue })
-          }
-        );
+      if (!taskValue) {
+        alert("Please enter a task!");
+        return;
+      }
 
-        if (response.ok) {
-          // Clear the task input
-          taskInput.value = "";
-
-          // Fetch the updated task list and update the view
-          fetchTasks();
+      const response = await fetch(
+        `${API_BASE}/tasks/add/task`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json"
+          },
+          body: JSON.stringify({ task: taskValue })
         }
+      );
+
+      if (response.ok) {
+        // Clear the task input
+        taskInput.value = "";
+
+        // Fetch the updated task list and update the view
+        fetchTasks();
       }
     });
   }


### PR DESCRIPTION
## Summary
- fix event listener for adding tasks so it attaches correctly
- add API_BASE fallback for local use

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6855b888b1b883209acfc58bc8bce065